### PR TITLE
[WIP] Start extension to enable per command configuration

### DIFF
--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -65,7 +65,7 @@ export class CommandProcessor {
 		})
 	}
 
-	prepareCommandsForFile (filePath: string): (BackendCommand | TerminalCommand | VSCodeCommand)[] {
+	prepareCommandsForFile (filePath: string, beforeSave: boolean = false): (BackendCommand | TerminalCommand | VSCodeCommand)[] {
 		let filteredCommands = this.filterCommandsForFile(filePath)
 
 		let formattedCommands = filteredCommands.map((command) => {
@@ -94,7 +94,7 @@ export class CommandProcessor {
 		return formattedCommands
 	}
 
-	private filterCommandsForFile(filePath: string): ProcessedCommand[] {
+	private filterCommandsForFile(filePath: string, beforeSave: boolean = false): ProcessedCommand[] {
 		return this.commands.filter(({match, notMatch}) => {
 			if (match && !match.test(filePath)) {
 				return false
@@ -208,6 +208,14 @@ export class RunOnSaveExtension {
 		if (commandsToRun.length > 0) {
 			this.runCommands(commandsToRun)
 		}
+	}
+
+	onDocumentBeforeSave(document: vscode.TextDocument) {
+		if (!this.getEnabled()) {
+			return
+		}
+
+		// TODO
 	}
 
 	private runCommands(commands: (BackendCommand | TerminalCommand | VSCodeCommand) []) {


### PR DESCRIPTION
Enable feature to define if command is run before or after save is executed as defined by  #7.

@pucelle There are multiple options on how to implement it:

1. Global option
2. Per command base (add option to run `runBeforeSave: true` with default)
3. Add new commands array `"runOnSave.beforeSaveCommands"`

I would have gone for option 2 or 3, since it enables more flexibility, what do you think?
