### PR TITLE
Add support for `${fileDirnameRelative}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For more details please refer to [VSCode Tasks](https://code.visualstudio.com/do
 | `${fileBasename}`            | the basename part of current opened file.
 | `${fileBasenameNoExtension}` | the basename part without extension of current opened file.
 | `${fileDirname}`             | the dirname path part of current opened file.
+| `${fileDirnameRelative}`     | the relative dirname path part of current opened file.
 | `${fileExtname}`             | the extension part of current opened file.
 | `${fileRelative}`            | the shorter relative path from current vscode working directory.
 | `${cwd}`                     | the task runner's current working directory on startup.

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -153,6 +153,7 @@ export class CommandProcessor {
 			'fileBasename',
 			'fileBasenameNoExtension', 
 			'fileDirname',
+			'fileDirnameRelative',
 			'fileExtname',
 			'fileRelative',
 			'cwd',
@@ -211,6 +212,9 @@ export class CommandProcessor {
 
 			case 'fileDirname':
 				return this.getDirName(filePath)
+
+			case 'fileDirnameRelative':
+				return this.getDirName(path.relative(vscode.workspace.rootPath || '', filePath))
 
 			case 'fileExtname':
 				return path.extname(filePath)


### PR DESCRIPTION
Very small PR that adds support for `${fileDirnameRelative}` which I needed for older versions of `rsync` in order to [create nested directories](https://stackoverflow.com/questions/1636889/rsync-how-can-i-configure-it-to-create-target-directory-on-server#22908437) on the target server.