### PR TITLE
Extends variable substitution capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 			"properties": {
 				"runOnSave.statusMessageTimeout": {
 					"type": "number",
-					"description": "Sepcify the timeout in millisecond after which the status message will be hidden. Works when `runIn=backend`, can be overwriten by the `statusMessageTimeout` in each command.",
+					"description": "Specify the timeout in millisecond after which the status message will be hidden. Works when `runIn=backend`, can be overwriten by the `statusMessageTimeout` in each command.",
 					"default": 3000
 				},
 				"runOnSave.ignoreFilesBy": {

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -95,14 +95,14 @@ export class CommandProcessor {
 	
 	/** Prepare raw commands to link current working file. */
 	private prepareCommandsForFile(uri: vscode.Uri, forCommandsAfterSaving: boolean) {
-		let filteredCommands = this.filterCommandsFromFilePath(uri)
+		const filteredCommands = this.filterCommandsFromFilePath(uri)
 
-		let processedCommands = filteredCommands.map((command) => {
-			let commandString = forCommandsAfterSaving
+		const processedCommands = filteredCommands.map((command) => {
+			const commandString = forCommandsAfterSaving
 				? command.commandBeforeSaving
 				: command.command
 
-			let pathSeparator = command.forcePathSeparator
+			const pathSeparator = command.forcePathSeparator
 
 			if (!commandString) {
 				return null
@@ -166,7 +166,7 @@ export class CommandProcessor {
 			return ''
 		}
 
-		let variables = [
+		const variables = [
 			'workspaceFolder',
 			'workspaceFolderBasename', 
 			'file',
@@ -177,6 +177,7 @@ export class CommandProcessor {
 			'fileExtname',
 			'fileRelative',
 			'cwd',
+			'selectedText',
 			'env',
 			'config',
 		]
@@ -184,7 +185,7 @@ export class CommandProcessor {
 		// if white spaces in file name or directory name, we need to wrap them in "".
 		// we doing this by testing each pieces, and wrap them if needed.
 		return commandOrMessage.replace(/\S+/g, (piece: string) => {
-			let oldPiece = piece
+			const oldPiece = piece
 			let alreadyQuoted = false
 
 			if (piece[0] === '"' && piece[piece.length - 1] === '"') {
@@ -213,14 +214,14 @@ export class CommandProcessor {
 
 	/** Get each variable value from its name. */
 	private getVariableValue(prefix: string, name: string, uri: vscode.Uri) {
-		switch(prefix) {
+		switch (prefix) {
 			case 'env':
 				return process.env[name] || ''
 			case 'config':
 				return vscode.workspace.getConfiguration("", uri)?.get(name)?.toString() || ''
 		}
 
-		switch(name) {
+		switch (name) {
 			case 'workspaceFolder':
 				return this.getRootPath(uri)
 
@@ -250,6 +251,10 @@ export class CommandProcessor {
 
 			case 'cwd':
 				return process.cwd()
+			
+			case 'selectedText':
+				const editor = vscode.window.activeTextEditor
+				return editor?.document.getText(editor.selection) || ''
 
 			default:
 				return ''
@@ -267,11 +272,7 @@ export class CommandProcessor {
 
 	// `path.dirname(...)` can't handle paths like `\\dir\name`.
 	private getDirName(filePath: string): string {
-		let dir = filePath.replace(/[\\\/][^\\\/]+$/, '')
-		if (!dir) {
-			dir = filePath[0] || ''
-		}
-		return dir
+		return filePath.replace(/[\\\/][^\\\/]+$/, '') || filePath[0] || ''
 	}
 
 	private getRootPath(uri: vscode.Uri): string {
@@ -285,7 +286,7 @@ export class CommandProcessor {
 		}
 
 		if (Array.isArray(args)) {
-			for (let arg of args) {
+			for (const arg of args) {
 				command += ' ' + this.encodeCommandLineToBeQuotedIf(arg)
 			}
 		}
@@ -293,7 +294,7 @@ export class CommandProcessor {
 			command += ' ' + args
 		}
 		else if (typeof args === 'object') {
-			for (let [key, value] of Object.entries(args)) {
+			for (const [key, value] of Object.entries(args)) {
 				command += ' ' + key + ' ' + this.encodeCommandLineToBeQuotedIf(value)
 			}
 		}

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -287,10 +287,9 @@ export class CommandProcessor {
 				return process.execPath
 			
 			case 'defaultBuildTask':
-				// TODO: Needs to filter for only build tasks.
-				// Currently returning the first default task.
-				const tasks = await vscode.tasks.fetchTasks()
-				return tasks.find(t => t.group?.isDefault)?.name || ''
+				return (await vscode.tasks.fetchTasks())
+					.find(t => t.group?.id == vscode.TaskGroup.Build.id && t.group.isDefault)
+					?.name || ''
 
 			case 'pathSeparator':
 				return path.sep

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -148,7 +148,7 @@ export class CommandProcessor {
 			}
 
 			if (globMatch) {
-				if (/\$\{\w+\}/.test(globMatch)) {
+				if (/\${((\w+):)?(\w+)}/.test(globMatch)) {
 					globMatch = this.formatVariables(globMatch, undefined, uri)
 				}
 

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -70,7 +70,7 @@ export class CommandProcessor {
 
 	private vars = Vars.of({
 		env: name => process.env[name] || '',
-		config: (name, uri) => vscode.workspace.getConfiguration("", uri)?.get(name)?.toString() || '',
+		config: (name, uri) => vscode.workspace.getConfiguration("", uri)?.get<string>(name) || '',
 		command: async name => await vscode.commands.executeCommand(name)
 	})
 

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -177,6 +177,7 @@ export class CommandProcessor {
 			'fileExtname',
 			'fileRelative',
 			'cwd',
+			'env',
 		]
 
 		// if white spaces in file name or directory name, we need to wrap them in "".
@@ -190,15 +191,14 @@ export class CommandProcessor {
 				alreadyQuoted = true
 			}
 
-			piece = piece.replace(/\${(\w+)}/g, (m0: string, name: string) => {
-				if (variables.includes(name)) {
-					let value = this.getPathVariableValue(name, filePath)
+			piece = piece.replace(/\${(?:(\w+):)?(\w+)}/g, (m0: string, prefix: string, name: string) => {
+				if (variables.includes(prefix || name)) {
+					let value = this.getPathVariableValue(prefix, name, filePath)
 					value = this.formatPathSeparator(value, pathSeparator)
 					return value
 				}
-				else {
-					return m0
-				}
+
+				return m0
 			})
 			
 			piece = piece.replace(/\${env\.([\w]+)}/g, (_sub: string, envName: string) => {
@@ -214,8 +214,13 @@ export class CommandProcessor {
 		})
 	}
 
-	/** Get each path variable value from it's name. */
-	private getPathVariableValue(name: string, filePath: string) {
+	/** Get each path variable value from its name. */
+	private getPathVariableValue(prefix: string, name: string, filePath: string) {
+		switch(prefix) {
+			case 'env':
+				return process.env[name] || ''
+		}
+
 		switch(name) {
 			case 'workspaceFolder':
 				return vscode.workspace.rootPath || ''

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -148,7 +148,7 @@ export class CommandProcessor {
 			}
 
 			if (globMatch) {
-				if (/\${((\w+):)?([\w\.]+)}/.test(globMatch)) {
+				if (/\${(?:\w+:)?[\w\.]+}/.test(globMatch)) {
 					globMatch = this.formatVariables(globMatch, undefined, uri)
 				}
 

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -148,7 +148,7 @@ export class CommandProcessor {
 			}
 
 			if (globMatch) {
-				if (/\${((\w+):)?(\w+)}/.test(globMatch)) {
+				if (/\${((\w+):)?([\w\.]+)}/.test(globMatch)) {
 					globMatch = this.formatVariables(globMatch, undefined, uri)
 				}
 

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -37,7 +37,7 @@ export interface ProcessedCommand {
 	async?: boolean
 }
 
-/** The commands in list will be picked by current editting file path. */
+/** The commands in list will be picked by current editing file path. */
 export interface BackendCommand {
 	runIn: 'backend'
 	command: string
@@ -123,7 +123,7 @@ export class CommandProcessor {
 	
 	/** Prepare raw commands to link current working file. */
 	private async prepareCommandsForFile(uri: vscode.Uri, forCommandsAfterSaving: boolean) {
-		let preparedCommands = []
+		const preparedCommands = []
 
 		for (const command of await this.filterCommandsFromFilePath(uri)) {
 			const commandString = forCommandsAfterSaving
@@ -164,7 +164,7 @@ export class CommandProcessor {
 	}
 
 	private async filterCommandsFromFilePath(uri: vscode.Uri): Promise<ProcessedCommand[]> {
-		let filteredCommands = []
+		const filteredCommands = []
 
 		for (const command of this.commands) {
 			let {match, notMatch, globMatch} = command
@@ -249,11 +249,7 @@ export class CommandProcessor {
 
 	/** Replace path separators. */
 	private formatPathSeparator(path: string, pathSeparator: string | undefined) {
-		if (pathSeparator) {
-			path = path.replace(/[\\|\/]/g, pathSeparator)
-		}
-
-		return path
+		return pathSeparator ? path.replace(/[\\|\/]/g, pathSeparator) : path
 	}
 
 	// `path.dirname(...)` can't handle paths like `\\dir\name`.
@@ -262,7 +258,6 @@ export class CommandProcessor {
 	}
 
 	private getRootPath(uri: vscode.Uri, scope?: string): string {
-		// TODO: get workspace when specified: vsCode.Uri.joinPath
 		uri = scope ? vscode.Uri.file(scope) : uri
 		return vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath || ''
 	}

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -1,7 +1,8 @@
 import * as path from 'path'
 import * as vscode from 'vscode'
-import {encodeCommandLineToBeQuoted, decodeQuotedCommandLine} from './util'
+import { encodeCommandLineToBeQuoted, decodeQuotedCommandLine } from './util'
 import * as minimatch from 'minimatch'
+import { homedir } from 'os'
 
 
 /** Raw command configured by user. */
@@ -94,97 +95,106 @@ export class CommandProcessor {
 	}
 	
 	/** Prepare raw commands to link current working file. */
-	private prepareCommandsForFile(uri: vscode.Uri, forCommandsAfterSaving: boolean) {
-		const filteredCommands = this.filterCommandsFromFilePath(uri)
+	private async prepareCommandsForFile(uri: vscode.Uri, forCommandsAfterSaving: boolean) {
+		let preparedCommands = []
 
-		const processedCommands = filteredCommands.map((command) => {
+		for (const command of await this.filterCommandsFromFilePath(uri)) {
 			const commandString = forCommandsAfterSaving
-				? command.commandBeforeSaving
-				: command.command
+			? command.commandBeforeSaving
+			: command.command
+
+			if (!commandString) {
+				continue
+			}
 
 			const pathSeparator = command.forcePathSeparator
 
-			if (!commandString) {
-				return null
-			}
-
 			if (command.runIn === 'backend') {
-				return {
+				preparedCommands.push({
 					runIn: 'backend',
-					command: this.formatArgs(this.formatVariables(commandString, pathSeparator, uri, true), command.args),
-					runningStatusMessage: this.formatVariables(command.runningStatusMessage, pathSeparator, uri),
-					finishStatusMessage: this.formatVariables(command.finishStatusMessage, pathSeparator, uri),
-					async: command.async ?? true,
-				} as BackendCommand
-			}
-			else if (command.runIn === 'terminal') {
-				return {
+					command: this.formatArgs(await this.formatVariables(commandString, pathSeparator, uri, true), command.args),
+					runningStatusMessage: await this.formatVariables(command.runningStatusMessage, pathSeparator, uri),
+					finishStatusMessage: await this.formatVariables(command.finishStatusMessage, pathSeparator, uri),
+					async: command.async ?? true,			
+				} as BackendCommand)
+			} else if (command.runIn === 'terminal') {
+				preparedCommands.push({
 					runIn: 'terminal',
-					command: this.formatArgs(this.formatVariables(commandString, pathSeparator, uri, true), command.args),
+					command: this.formatArgs(await this.formatVariables(commandString, pathSeparator, uri, true), command.args),
 					async: command.async ?? true,
-				} as TerminalCommand
-			}
-			else {
-				return {
+				} as TerminalCommand)
+			} else {
+				preparedCommands.push({
 					runIn: 'vscode',
-					command: this.formatVariables(commandString, pathSeparator, uri, true),
+					command: await this.formatVariables(commandString, pathSeparator, uri, true),
 					args: command.args,
 					async: command.async ?? true,
-				} as VSCodeCommand
+				} as VSCodeCommand)
 			}
-		})
+		}
 
-		return processedCommands.filter(v => v) as (BackendCommand | TerminalCommand | VSCodeCommand)[]
+		return preparedCommands
 	}
 
-	private filterCommandsFromFilePath(uri: vscode.Uri): ProcessedCommand[] {
-		return this.commands.filter(({match, notMatch, globMatch}) => {
-			if (match && !match.test(uri.fsPath)) {
-				return false
-			}
+	private async filterCommandsFromFilePath(uri: vscode.Uri): Promise<ProcessedCommand[]> {
+		let filteredCommands = []
 
+		for (const command of this.commands) {
+			let {match, notMatch, globMatch} = command
+			if (match && !match.test(uri.fsPath)) {
+				continue
+			}
 			if (notMatch && notMatch.test(uri.fsPath)) {
-				return false
+				continue
 			}
 
 			if (globMatch) {
 				if (/\${(?:\w+:)?[\w\.]+}/.test(globMatch)) {
-					globMatch = this.formatVariables(globMatch, undefined, uri)
+					globMatch = await this.formatVariables(globMatch, undefined, uri)
 				}
 
 				if (!minimatch(uri.fsPath, globMatch)) {
-					return false
+					continue
 				}
 			}
 
-			return true
-		})
+			filteredCommands.push(command)
+		}
+
+		return filteredCommands
 	}
 
-	private formatVariables(commandOrMessage: string, pathSeparator: PathSeparator | undefined, uri: vscode.Uri, isCommand: boolean = false): string {
+	private async formatVariables(commandOrMessage: string, pathSeparator: PathSeparator | undefined, uri: vscode.Uri, isCommand: boolean = false): Promise<string> {
 		if (!commandOrMessage) {
 			return ''
 		}
 
 		const variables = [
+			'userHome',
 			'workspaceFolder',
-			'workspaceFolderBasename', 
+			'workspaceFolderBasename',
 			'file',
+			'fileWorkspaceFolder',
+			'relativeFile',
+			'relativeFileDirname',
 			'fileBasename',
-			'fileBasenameNoExtension', 
-			'fileDirname',
-			'fileDirnameRelative',
+			'fileBasenameNoExtension',
 			'fileExtname',
-			'fileRelative',
+			'fileDirname',
+			'fileDirnameBasename',
 			'cwd',
+			'lineNumber',
 			'selectedText',
+			'execPath',
+			'defaultBuildTask',
+			'pathSeparator',
 			'env',
 			'config',
 		]
 
 		// if white spaces in file name or directory name, we need to wrap them in "".
 		// we doing this by testing each pieces, and wrap them if needed.
-		return commandOrMessage.replace(/\S+/g, (piece: string) => {
+		return this.replaceAsync(commandOrMessage, /\S+/g, async (piece: string) => {
 			const oldPiece = piece
 			let alreadyQuoted = false
 
@@ -193,9 +203,9 @@ export class CommandProcessor {
 				alreadyQuoted = true
 			}
 
-			piece = piece.replace(/\${(?:(\w+):)?([\w\.]+)}/g, (m0: string, prefix: string, name: string) => {
+			piece = await this.replaceAsync(piece, /\${(?:(\w+):)?([\w\.]+)}/g, async (m0: string, prefix: string, name: string) => {
 				if (variables.includes(prefix || name)) {
-					let value = this.getVariableValue(prefix, name, uri)
+					let value = await this.getVariableValue(prefix, name, uri)
 					value = this.formatPathSeparator(value, pathSeparator)
 					return value
 				}
@@ -213,23 +223,41 @@ export class CommandProcessor {
 	}
 
 	/** Get each variable value from its name. */
-	private getVariableValue(prefix: string, name: string, uri: vscode.Uri) {
-		switch (prefix) {
-			case 'env':
-				return process.env[name] || ''
-			case 'config':
-				return vscode.workspace.getConfiguration("", uri)?.get(name)?.toString() || ''
+	private async getVariableValue(prefix: string, name: string, uri: vscode.Uri) {
+		let scope
+
+		if (prefix) {
+			switch (prefix) {
+				case 'env':
+					return process.env[name] || ''
+				case 'config':
+					return vscode.workspace.getConfiguration("", uri)?.get(name)?.toString() || ''
+			}
+
+			[scope, name] = [name, prefix]
 		}
 
 		switch (name) {
+			case 'userHome':
+				return homedir()
+
 			case 'workspaceFolder':
-				return this.getRootPath(uri)
+				return this.getRootPath(uri, scope)
 
 			case 'workspaceFolderBasename':
-				return path.basename(this.getRootPath(uri))
+				return path.basename(this.getRootPath(uri, scope))
 
 			case 'file':
 				return uri.fsPath
+			
+			case 'fileWorkspaceFolder':
+				return this.getRootPath(uri)
+
+			case 'relativeFile':
+				return path.relative(this.getRootPath(uri, scope), uri.fsPath)
+
+			case 'relativeFileDirname':
+				return this.getDirName(path.relative(this.getRootPath(uri, scope), uri.fsPath))
 
 			case 'fileBasename':
 				return path.basename(uri.fsPath)
@@ -237,24 +265,35 @@ export class CommandProcessor {
 			case 'fileBasenameNoExtension':
 				return path.basename(uri.fsPath, path.extname(uri.fsPath))
 
-			case 'fileDirname':
-				return this.getDirName(uri.fsPath)
-
-			case 'fileDirnameRelative':
-				return this.getDirName(path.relative(this.getRootPath(uri), uri.fsPath))
-
 			case 'fileExtname':
 				return path.extname(uri.fsPath)
 
-			case 'fileRelative':
-				return path.relative(this.getRootPath(uri), uri.fsPath)
+			case 'fileDirname':
+				return this.getDirName(uri.fsPath)
+
+			case 'fileDirnameBasename':
+				return path.basename(this.getDirName(uri.fsPath))
 
 			case 'cwd':
 				return process.cwd()
+
+			case 'lineNumber':
+				return this.editor?.selection.active.line.toString() || ''
 			
 			case 'selectedText':
-				const editor = vscode.window.activeTextEditor
-				return editor?.document.getText(editor.selection) || ''
+				return this.editor?.document.getText(this.editor.selection) || ''
+			
+			case 'execPath':
+				return process.execPath
+			
+			case 'defaultBuildTask':
+				// TODO: Needs to filter for only build tasks.
+				// Currently returning the first default task.
+				const tasks = await vscode.tasks.fetchTasks()
+				return tasks.find(t => t.group?.isDefault)?.name || ''
+
+			case 'pathSeparator':
+				return path.sep
 
 			default:
 				return ''
@@ -275,7 +314,9 @@ export class CommandProcessor {
 		return filePath.replace(/[\\\/][^\\\/]+$/, '') || filePath[0] || ''
 	}
 
-	private getRootPath(uri: vscode.Uri): string {
+	private getRootPath(uri: vscode.Uri, scope?: string): string {
+		// TODO: get workspace when specified: vsCode.Uri.joinPath
+		uri = scope ? vscode.Uri.file(scope) : uri
 		return vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath || ''
 	}
 
@@ -302,12 +343,26 @@ export class CommandProcessor {
 		return command
 	}
 
-	/** If piece includes spaces, `\\`, or be quoted, then it must be encoded. */
+	/** If piece includes spaces, `\\`, or is quoted, then it must be encoded. */
 	private encodeCommandLineToBeQuotedIf(arg: string) {
 		if (/[\s"]|\\\\/.test(arg)) {
 			arg = '"' + encodeCommandLineToBeQuoted(arg) + '"'
 		}
 
 		return arg
+	}
+
+	private async replaceAsync(str: string, searchValue: RegExp, replacer: (...matches: string[]) => Promise<string>): Promise<string> {
+		const replacements = await Promise.all(
+			Array.from(str.matchAll(searchValue),
+			match => replacer(...match))
+		);
+
+		let i = 0;
+		return str.replace(searchValue, () => replacements[i++]);
+	}
+
+	private get editor() {
+		return vscode.window.activeTextEditor
 	}
 }

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -70,7 +70,8 @@ export class CommandProcessor {
 
 	private vars = Vars.of({
 		env: name => process.env[name] || '',
-		config: (name, uri) => vscode.workspace.getConfiguration("", uri)?.get(name)?.toString() || ''
+		config: (name, uri) => vscode.workspace.getConfiguration("", uri)?.get(name)?.toString() || '',
+		command: async name => await vscode.commands.executeCommand(name)
 	})
 
 	private values = Vars.of({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import {RunOnSaveExtension} from './run-on-save';
 
 
 export function activate(context: vscode.ExtensionContext): RunOnSaveExtension {
-	let extension = new RunOnSaveExtension(context)
+	const extension = new RunOnSaveExtension(context)
 
 	context.subscriptions.push(
 		vscode.workspace.onDidChangeConfiguration(() => {

--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -60,11 +60,7 @@ export class RunOnSaveExtension {
 
 	/** Returns a promise it was resolved firstly and then save document. */
 	async onWillSaveDocument(document: vscode.TextDocument | vscode.NotebookDocument) {
-		if (!this.getEnabled()) {
-			return
-		}
-
-		if (await this.shouldIgnore(document.uri)) {
+		if (!this.getEnabled() || await this.shouldIgnore(document.uri)) {
 			return
 		}
 
@@ -175,7 +171,7 @@ export class RunOnSaveExtension {
 	}
 
 	private async runTerminalCommand(command: TerminalCommand) {
-		let terminal = this.createTerminal()
+		const terminal = this.createTerminal()
 
 		terminal.show()
 		terminal.sendText(command.command)
@@ -190,7 +186,7 @@ export class RunOnSaveExtension {
 	}
 
 	private createTerminal(): vscode.Terminal {
-		let terminalName = 'Run on Save'
+		const terminalName = 'Run on Save'
 		let terminal = vscode.window.terminals.find(terminal => terminal.name === terminalName)
 
 		if (!terminal) {
@@ -201,8 +197,7 @@ export class RunOnSaveExtension {
 	}
 
 	private async runVSCodeCommand(command: VSCodeCommand) {
-
-		// finishStatusMessage have to be hooked to exit of command execution
+		// finishStatusMessage has to be hooked to exit of command execution
 		this.showChannelMessage(`Running "${command.command}"`)
 
 		let args: any[]

--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -121,12 +121,10 @@ export class RunOnSaveExtension {
 		if (command.runIn === 'backend') {
 			return this.runBackendCommand(command)
 		}
-		else if (command.runIn === 'terminal') {
+		if (command.runIn === 'terminal') {
 			return this.runTerminalCommand(command)
 		}
-		else {
-			return this.runVSCodeCommand(command)
-		}
+		return this.runVSCodeCommand(command)
 	}
 
 	private runBackendCommand(command: BackendCommand) {

--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -68,7 +68,7 @@ export class RunOnSaveExtension {
 			return
 		}
 
-		let commandsToRun = this.commandProcessor.prepareCommandsForFileBeforeSaving(document.uri.fsPath)
+		let commandsToRun = this.commandProcessor.prepareCommandsForFileBeforeSaving(document.uri)
 		if (commandsToRun.length > 0) {
 			await this.runCommands(commandsToRun)
 		}
@@ -83,7 +83,7 @@ export class RunOnSaveExtension {
 			return
 		}
 
-		let commandsToRun = this.commandProcessor.prepareCommandsForFileAfterSaving(document.uri.fsPath)
+		let commandsToRun = this.commandProcessor.prepareCommandsForFileAfterSaving(document.uri)
 		if (commandsToRun.length > 0) {
 			await this.runCommands(commandsToRun)
 		}

--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -185,20 +185,16 @@ export class RunOnSaveExtension {
 		// finishStatusMessage has to be hooked to exit of command execution
 		this.showChannelMessage(`Running "${command.command}"`)
 
-		let args: any[]
-
-		if (Array.isArray(command.args)) {
-			args = command.args
-		}
-		else if (typeof command.args === 'string') {
-			args = [command.args]
-		}
-		else if (typeof command.args === 'object') {
-			args = [command.args]
-		}
-		else {
-			args = []
-		}
+		const args = ((args) => {
+			if (Array.isArray(args)) {
+				return args
+			}
+			const argsType = typeof args
+			if (['string', 'object'].some(t => t === argsType)) {
+				return [args]
+			}
+			return []
+		})(command.args)
 
 		await vscode.commands.executeCommand(command.command, ...args)
 	}

--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -34,7 +34,7 @@ export class RunOnSaveExtension {
 	}
 
 	private showEnablingChannelMessage () {
-		let message = `Run on Save is ${this.getEnabled() ? 'enabled' : 'disabled'}`
+		const message = `Run on Save is ${this.getEnabled() ? 'enabled' : 'disabled'}`
 		this.showChannelMessage(message)
 		this.showStatusMessage(message)
 	}
@@ -54,7 +54,7 @@ export class RunOnSaveExtension {
 
 	private showStatusMessage(message: string, timeout?: number) {
 		timeout = timeout || this.config.get('statusMessageTimeout') || 3000
-		let disposable = vscode.window.setStatusBarMessage(message, timeout)
+		const disposable = vscode.window.setStatusBarMessage(message, timeout)
 		this.context.subscriptions.push(disposable)
 	}
 
@@ -68,7 +68,7 @@ export class RunOnSaveExtension {
 			return
 		}
 
-		let commandsToRun = this.commandProcessor.prepareCommandsForFileBeforeSaving(document.uri)
+		const commandsToRun = await this.commandProcessor.prepareCommandsForFileBeforeSaving(document.uri)
 		if (commandsToRun.length > 0) {
 			await this.runCommands(commandsToRun)
 		}
@@ -83,14 +83,14 @@ export class RunOnSaveExtension {
 			return
 		}
 
-		let commandsToRun = this.commandProcessor.prepareCommandsForFileAfterSaving(document.uri)
+		const commandsToRun = await this.commandProcessor.prepareCommandsForFileAfterSaving(document.uri)
 		if (commandsToRun.length > 0) {
 			await this.runCommands(commandsToRun)
 		}
 	}
 
 	private async shouldIgnore(uri: vscode.Uri): Promise<boolean> {
-		let checker = new FileIgnoreChecker({
+		const checker = new FileIgnoreChecker({
 			workspaceDir: vscode.workspace.getWorkspaceFolder(uri)?.uri.fsPath,
 			ignoreFilesBy: this.config.get('ignoreFilesBy') || [],
 		})
@@ -99,9 +99,9 @@ export class RunOnSaveExtension {
 	}
 
 	private async runCommands(commands: (BackendCommand | TerminalCommand | VSCodeCommand)[]) {
-		let promises: Promise<void>[] = []
-		let syncCommands = commands.filter(c => !c.async)
-		let asyncCommands = commands.filter(c => c.async)
+		const promises: Promise<void>[] = []
+		const syncCommands = commands.filter(c => !c.async)
+		const asyncCommands = commands.filter(c => c.async)
 
 		// Run commands in a parallel.
 		for (let command of asyncCommands) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,10 +7,7 @@ export function decodeQuotedCommandLine(command: string) {
 	return command.replace(/\\(.)/g, '$1')
 }
 
-
 /** Resolves the returned promise after `ms` millseconds. */
 export function timeout(ms: number): Promise<void> {
-	return new Promise(resolve => {
-		setTimeout(resolve, ms)
-	})
+	return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/test/src/extension.test.ts
+++ b/test/src/extension.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert'
+import * as path from 'path'
+import {Uri} from 'vscode'
 import {RawCommand, CommandProcessor} from '../../out/command-processor'
 import {FileIgnoreChecker} from '../../out/file-ignore-checker'
-import * as path from 'path'
 
 
 suite("Extension Tests", () => {
@@ -17,7 +18,7 @@ suite("Extension Tests", () => {
 		}])
 
 		test('will compile scss file in backend', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('folderName/fileName.scss')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('folderName/fileName.scss'))
 			assert.deepStrictEqual(commands, [{
 				'runIn': 'backend',
 				'command': 'node-sass folderName/fileName.scss folderName/fileName.css',
@@ -28,12 +29,12 @@ suite("Extension Tests", () => {
 		})
 
 		test('will exclude scss file that file name starts with "_"', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('folderName/_fileName.scss')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('folderName/_fileName.scss'))
 			assert.deepStrictEqual(commands, [])
 		})
 		
 		test('will escape white spaces', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('folderName/fileName 1.scss')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('folderName/fileName 1.scss'))
 			assert.deepStrictEqual(
 				commands[0].command,
 				'node-sass "folderName/fileName 1.scss" "folderName/fileName 1.css"'
@@ -54,7 +55,7 @@ suite("Extension Tests", () => {
 		}])
 
 		test('will compile scss file in backend', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('folderName/fileName.scss')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('folderName/fileName.scss'))
 			assert.deepStrictEqual(commands, [{
 				'runIn': 'backend',
 				'command': 'node-sass folderName/fileName.scss folderName/fileName.css',
@@ -78,7 +79,7 @@ suite("Extension Tests", () => {
 		}])
 
 		test('will compile scss file in backend', function () {
-			let commands = manager.prepareCommandsForFileBeforeSaving('folderName/fileName.scss')
+			let commands = manager.prepareCommandsForFileBeforeSaving(Uri.file('folderName/fileName.scss'))
 			assert.deepStrictEqual(commands, [{
 				'runIn': 'backend',
 				'command': 'node-sass folderName/fileName.scss folderName/fileName.css',
@@ -102,7 +103,7 @@ suite("Extension Tests", () => {
 		}])
 
 		test('will escape paths starts with "\\\\"', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('\\\\folderName\\fileName 1.scss')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('\\\\folderName\\fileName 1.scss'))
 			assert.deepStrictEqual(
 				commands[0].command,
 				'node-sass "\\\\folderName\\fileName 1.scss" "\\\\folderName\\fileName 1.css"'
@@ -121,7 +122,7 @@ suite("Extension Tests", () => {
 		}])
 
 		test('will compile scss file in terminal', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('folderName/fileName.scss')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('folderName/fileName.scss'))
 			assert.deepStrictEqual(commands, [{
 				'runIn': 'terminal',
 				'command': 'node-sass folderName/fileName.scss folderName/fileName.css',
@@ -140,7 +141,7 @@ suite("Extension Tests", () => {
 		}])
 
 		test('will compile it right', function () {
-			let commands = manager.prepareCommandsForFileAfterSaving('test.drawio')
+			let commands = manager.prepareCommandsForFileAfterSaving(Uri.file('test.drawio'))
 			assert.deepStrictEqual(commands, [{
 				'runIn': 'backend',
 				'command': 'draw.io --crop --export -f pdf "test.drawio"',


### PR DESCRIPTION
An example of how I'm using this:

```json
    "runOnSave.commands": [
        {
            // Match dotfiles
            "globMatch": "${env:XDG_DATA_HOME}/chezmoi/**",
            "command": "cfg apply",
            "runIn": "terminal",
            "runningStatusMessage": "Applying ${fileBasename}",
            "finishStatusMessage": "${fileBasename} applied"
        }
    ]
```

Previously using an environment variable in `globMatch` like this didn't work.

Another use case this PR supports is using the currently selected text:

```json
    "runOnSave.commands": [
        {
            "command": "echo ${selectedText}",
            "runIn": "terminal"
        }
    ]
```

This PR provides *almost* complete support for VS Code variables; only `{input:XXX}` is unsupported. The reason for this is that the argument here links to an input control defined in `tasks.json`, and there appears to be no way to pull those programmatically at this time; parsing `tasks.json` manually may be a workaround, but feels ugly.

This PR also addresses the deprecated `rootPath` property.

For some reason I had to remove the `postinstall` step from `package.json`, which points at a command that (for me) didn't exist; I've consciously avoided committing that change.

Happy to make any changes required, just let me know what you need!