### PR TITLE
Add an Option to Only Run On Manual Save

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you need to run VS Code's commands change `runIn` option to `vscode`
 | `runOnSave.ignoreFilesBy`        | Specifies it to ignore files that list in `.gitignore` or `.npmignore`. default value is empty list.
 | `runOnSave.shell`                | Specify in which shell the commands are executed, defaults to the default vscode shell.
 | `runOnSave.defaultRunIn`         | Specify default `runIn` for all the commands, it equals to `vscode` if not specified.
+| `runOnSave.onlyRunOnManualSave`  | Whether to only run commands when a file is manually saved, defaults to false.
 | `runOnSave.commands`             | Specify the array of commands to execute and related info, its child options as below.
 | `runOnSave.commandBeforeSaving`  | Same format as `runOnSave.commands`, but runs it before saving action happens, and document is not saved yet.
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
 						"Run vscode's command. Choose this if you want to execute vscode's own command or a command from a installed vscode extension."
 					]
 				},
+				"runOnSave.onlyRunOnManualSave": {
+					"type": "boolean",
+					"description": "Only run commands when manually saving a file. Default value is `false`.",
+					"default": false
+				},
 				"runOnSave.commands": {
 					"type": "array",
 					"description": "Shell commands array.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,11 +19,11 @@ export function activate(context: vscode.ExtensionContext): RunOnSaveExtension {
 		}),
 
 		vscode.workspace.onWillSaveTextDocument((e: vscode.TextDocumentWillSaveEvent) => {
-			e.waitUntil(extension.onWillSaveDocument(e.document))
+			e.waitUntil(extension.onWillSaveDocument(e.document, e.reason))
 		}),
 
 		vscode.workspace.onWillSaveNotebookDocument((e: vscode.NotebookDocumentWillSaveEvent) => {
-			e.waitUntil(extension.onWillSaveDocument(e.notebook))
+			e.waitUntil(extension.onWillSaveDocument(e.notebook, e.reason))
 		}),
 
 		vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
@@ -32,6 +32,10 @@ export function activate(context: vscode.ExtensionContext): RunOnSaveExtension {
 
 		vscode.workspace.onDidSaveNotebookDocument((document: vscode.NotebookDocument) => {
 			extension.onDocumentSaved(document)
+		}),
+
+		vscode.workspace.onDidDeleteFiles((e: vscode.FileDeleteEvent) => {
+			extension.onDidDeleteFiles(e)
 		}),
 	)
 

--- a/src/file-ignore-checker.ts
+++ b/src/file-ignore-checker.ts
@@ -36,7 +36,7 @@ export class FileIgnoreChecker {
 
 		let workspaceDir = this.workspaceDir
 		
-		// Not in current working dirctory, never ignore.
+		// Not in current working directory, never ignore.
 		if (workspaceDir && !path.normalize(filePath).startsWith(workspaceDir)) {
 			return false
 		}


### PR DESCRIPTION
I've found that if the command in question modifies the file I can get some annoying "Failed to save xyz: The content of the file is newer. [...]" errors when it triggers off of auto saves. This happens with `async: false` too so this is probably because the did save events don't expect modifications.

I'm sure the same issue technically exists during a manual save as well but it'd require saving and then very quickly editing which is unrealistic compared to an auto save. In addition it's a better user experience in some cases to only run on manual save.

Resolves #5 which @ragurney might be pleased to know, even if 4 years late.