### PR TITLE
feature: add doNotDisturb mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,6 +272,11 @@
 								"type": "boolean",
 								"description": "Clear the output channel before running. Default value is `false`.",
 								"default": false
+							},
+							"doNotDisturb": {
+								"type": "boolean",
+								"description": "Prevents the Output tab from being focused on non-zero exit codes. Only works when `runIn=backend`.",
+								"default": false
 							}
 						}
 					}

--- a/src/command-processor.ts
+++ b/src/command-processor.ts
@@ -21,6 +21,7 @@ export interface RawCommand {
 	finishStatusMessage: string
 	async?: boolean
 	clearOutput?: boolean
+	doNotDisturb?: boolean
 }
 
 /** Processed command, which can be run directly. */
@@ -37,6 +38,7 @@ export interface ProcessedCommand {
 	finishStatusMessage: string
 	async?: boolean
 	clearOutput?: boolean
+	doNotDisturb?: boolean
 }
 
 /** The commands in list will be picked by current editing file path. */
@@ -49,6 +51,7 @@ export interface BackendCommand {
 	async: boolean
 	statusMessageTimeout?: number
 	clearOutput?: boolean
+	doNotDisturb?: boolean
 }
 
 export interface TerminalCommand {
@@ -98,7 +101,7 @@ export class CommandProcessor {
 	prepareCommandsForFileAfterSaving(uri: vscode.Uri) {
 		return this.prepareCommandsForFile(uri, false)
 	}
-	
+
 	/** Prepare raw commands to link current working file. */
 	private async prepareCommandsForFile(uri: vscode.Uri, forCommandsAfterSaving: boolean) {
 		let preparedCommands = []
@@ -122,6 +125,7 @@ export class CommandProcessor {
 					finishStatusMessage: await this.formatVariables(command.finishStatusMessage, pathSeparator, uri),
 					async: command.async ?? true,
 					clearOutput: command.clearOutput ?? false,
+					doNotDisturb: command.doNotDisturb ?? false,
 				} as BackendCommand)
 			}
 			else if (command.runIn === 'terminal') {
@@ -187,7 +191,7 @@ export class CommandProcessor {
 			globMatch = await this.formatVariables(globMatch, undefined, uri)
 		}
 
-		let gm = new minimatch.Minimatch(globMatch) 
+		let gm = new minimatch.Minimatch(globMatch)
 
 		// If match whole path.
 		if (gm.match(uri.fsPath)) {

--- a/src/run-on-save.ts
+++ b/src/run-on-save.ts
@@ -46,7 +46,7 @@ export class RunOnSaveExtension {
 	private showChannelMessage(message: string) {
 		this.channel.appendLine(message)
 	}
-	
+
 	getEnabled(): boolean {
 		return !!this.context.globalState.get('enabled', true)
 	}
@@ -58,7 +58,7 @@ export class RunOnSaveExtension {
 
 	private showStatusMessage(message: string, timeout?: number) {
 		timeout = timeout || this.config.get('statusMessageTimeout') || 3000
-		
+
 		let disposable = vscode.window.setStatusBarMessage(message, timeout)
 		this.context.subscriptions.push(disposable)
 	}
@@ -146,17 +146,17 @@ export class RunOnSaveExtension {
 			if (command.runningStatusMessage) {
 				this.showStatusMessage(command.runningStatusMessage, command.statusMessageTimeout)
 			}
-	
+
 			let child = this.execShellCommand(command.command, command.workingDirectoryAsCWD ?? true)
 			child.stdout!.on('data', data => this.channel.append(data.toString()))
 			child.stderr!.on('data', data => this.channel.append(data.toString()))
-	
+
 			child.on('exit', (e) => {
 				if (e === 0 && command.finishStatusMessage) {
 					this.showStatusMessage(command.finishStatusMessage, command.statusMessageTimeout)
 				}
-	
-				if (e !== 0) {
+
+				if (e !== 0 && !command.doNotDisturb) {
 					this.channel.show(true)
 				}
 
@@ -209,7 +209,7 @@ export class RunOnSaveExtension {
 		let args = this.formatVSCodeCommandArgs(command.args)
 		await vscode.commands.executeCommand(command.command, ...args)
 	}
-	
+
 	private formatVSCodeCommandArgs(args: string | object | string[] | undefined): any[] {
 		if (Array.isArray(args)) {
 			return args


### PR DESCRIPTION
This is to prevent the Output window from being focused on every runOnSave command that throws a non-zero exit code (such as when there's a formatting error in a file). There are other tools that may catch this and it's convenient to keep the Terminal window focused at all times (i believe this was the original intention of "backend" mode)

Tested by creating the following command in an Extension Development Environment with the following settings.json:

```
{
  "runOnSave.commands": [
    {
        "globMatch": "**/*.js",
        "command": "exit 2",
        "runIn": "backend",
        "doNotDisturb": true
    }
  ]
}
```